### PR TITLE
fix(forms): Fix radio button label style

### DIFF
--- a/src/styles/modules/_forms.scss
+++ b/src/styles/modules/_forms.scss
@@ -275,6 +275,13 @@
     &:checked + .dc-label:after {
         background: $dc-blue40;
     }
+
+    + .dc-label {
+        font-size: $dc-body-font-size;
+        font-weight: $dc-normal-font-weight;
+        line-height: $dc-space150 - .2;
+        text-transform: none;
+    }
 }
 
 //  = CHECKBOX


### PR DESCRIPTION
The radio button label style did not match the checkbox button label style. Now they are aligned.