### PR TITLE
fix(sass-versions-compatibility): #82 use the placehodler syntax with… close #82

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "compass-breakpoint": "breakpoint-sass#~2.6.1",
-    "normalize-css": "normalize.css#~3.0.3",
     "susy": "~2.2.6",
     "modernizer": "~2.8.2"
   }

--- a/docs/demo/assets/fabricator/styles/fabricator.scss
+++ b/docs/demo/assets/fabricator/styles/fabricator.scss
@@ -5,7 +5,7 @@
  */
 
 // Reset
-@import "../../../../../node_modules/normalize-css/normalize";
+@import "../../../../../src/styles/normalize";
 
 // Breakpoint framework
 @import "../../../../../node_modules/breakpoint-sass/stylesheets/breakpoint";

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   },
   "dependencies": {
     "breakpoint-sass": "^2.6.1",
-    "normalize-css": "^2.3.1",
     "susy": "^2.2.6"
   }
 }

--- a/src/styles/_import.scss
+++ b/src/styles/_import.scss
@@ -1,5 +1,5 @@
 // Reset
-@import "../../node_modules/normalize-css/normalize";
+@import "./normalize";
 
 // Breakpoint framework
 @import "../../node_modules/breakpoint-sass/stylesheets/breakpoint";

--- a/src/styles/_normalize.scss
+++ b/src/styles/_normalize.scss
@@ -1,0 +1,347 @@
+// scss-lint:disable VendorPrefix QualifyingElement ColorVariable
+
+//! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css
+
+//  1. Set default font family to sans-serif.
+//  2. Prevent iOS and IE text size adjust after device orientation change,
+//     without disabling user zoom.
+
+html {
+    font-family: sans-serif; // 1
+    -ms-text-size-adjust: 100%; // 2
+    -webkit-text-size-adjust: 100%; // 2
+}
+
+// Remove default margin.
+body {
+    margin: 0;
+}
+
+// HTML5 display definitions
+// ==========================================================================
+
+// Correct `block` display not defined for any HTML5 element in IE 8/9.
+// Correct `block` display not defined for `details` or `summary` in IE 10/11
+// and Firefox.
+// Correct `block` display not defined for `main` in IE 11.
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+    display: block;
+}
+
+// 1. Correct `inline-block` display not defined in IE 8/9.
+// 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+
+audio,
+canvas,
+progress,
+video {
+    display: inline-block; // 1
+    vertical-align: baseline; // 2
+}
+
+// Prevent modern browsers from displaying `audio` without controls.
+// Remove excess height in iOS 5 devices.
+
+audio:not([controls]) {
+    display: none;
+    height: 0;
+}
+
+// Address `[hidden]` styling not present in IE 8/9/10.
+// Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+
+[hidden],
+template {
+    display: none;
+}
+
+// Links
+// ==========================================================================
+
+// Remove the gray background color from active links in IE 10.
+a {
+    background-color: transparent;
+}
+
+// Improve readability of focused elements when they are also
+// in an active/hover state.
+a:active,
+a:hover {
+    outline: 0;
+}
+
+// Text-level semantics
+// ==========================================================================
+
+// Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+abbr[title] {
+    border-bottom: 1px dotted;
+}
+
+// Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+
+b,
+strong {
+    font-weight: bold;
+}
+
+/////
+// Address styling not present in Safari and Chrome.
+
+dfn {
+    font-style: italic;
+}
+
+// Address variable `h1` font-size and margin within `section` and `article`
+// contexts in Firefox 4+, Safari, and Chrome.
+
+h1 {
+    margin: .67em 0;
+    font-size: 2em;
+}
+
+// Address styling not present in IE 8/9.
+
+mark {
+    background: #ff0;
+    color: #000;
+}
+
+// Address inconsistent and variable font size in all browsers.
+
+small {
+    font-size: 80%;
+}
+
+// Prevent `sub` and `sup` affecting `line-height` in all browsers.
+
+sub,
+sup {
+    position: relative;
+    font-size: 75%;
+    line-height: 0;
+    vertical-align: baseline;
+}
+
+sup {
+    top: -.5em;
+}
+
+sub {
+    bottom: -.25em;
+}
+
+// Embedded content
+// ==========================================================================
+
+// Remove border when inside `a` element in IE 8/9/10.
+
+img {
+    border: 0;
+}
+
+// Correct overflow not hidden in IE 9/10/11.
+
+svg:not(:root) {
+    overflow: hidden;
+}
+
+// Grouping content
+// ==========================================================================
+
+// Address margin not present in IE 8/9 and Safari.
+
+figure {
+    margin: 1em 40px;
+}
+
+// Address differences between Firefox and other browsers.
+
+hr {
+    height: 0;
+    box-sizing: content-box;
+}
+
+// Contain overflow in all browsers.
+
+pre {
+    overflow: auto;
+}
+
+// Address odd `em`-unit font size rendering in all browsers.
+
+code,
+kbd,
+pre,
+samp {
+    font-family: monospace, monospace;
+    font-size: 1em;
+}
+
+// Forms
+// ==========================================================================
+
+// Known limitation: by default, Chrome and Safari on OS X allow very limited
+// styling of `select`, unless a `border` property is set.
+
+// 1. Correct color not being inherited.
+//    Known issue: affects color of disabled elements.
+// 2. Correct font properties not being inherited.
+// 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+
+button,
+input,
+optgroup,
+select,
+textarea {
+    margin: 0;
+    color: inherit;
+    font: inherit;
+}
+
+// Address `overflow` set to `hidden` in IE 8/9/10/11.
+
+button {
+    overflow: visible;
+}
+
+// Address inconsistent `text-transform` inheritance for `button` and `select`.
+// All other form control elements do not inherit `text-transform` values.
+// Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+// Correct `select` style inheritance in Firefox.
+
+button,
+select {
+    text-transform: none;
+}
+
+// 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+//    and `video` controls.
+// 2. Correct inability to style clickable `input` types in iOS.
+// 3. Improve usability and consistency of cursor style between image-type
+//    `input` and others.
+
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+    cursor: pointer;
+    -webkit-appearance: button;
+}
+
+// Re-set default cursor for disabled elements.
+
+button[disabled],
+html input[disabled] {
+    cursor: default;
+}
+
+// Remove inner padding and border in Firefox 4+.
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+    padding: 0;
+    border: 0;
+}
+
+// Address Firefox 4+ setting `line-height` on `input` using `!important` in
+// the UA stylesheet.
+
+input {
+    line-height: normal;
+}
+
+// It's recommended that you don't attempt to style these elements.
+// Firefox's implementation doesn't respect box-sizing, padding, or width.
+//
+// 1. Address box sizing set to `content-box` in IE 8/9/10.
+// 2. Remove excess padding in IE 8/9/10.
+
+input[type="checkbox"],
+input[type="radio"] {
+    padding: 0;
+    box-sizing: border-box;
+}
+
+// Fix the cursor style for Chrome's increment/decrement buttons. For certain
+// `font-size` values of the `input`, it causes the cursor style of the
+// decrement button to change from `default` to `text`.
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+    height: auto;
+}
+
+// 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+// 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+
+input[type="search"] {
+    -webkit-appearance: textfield; // 1
+    box-sizing: content-box; // 2
+}
+
+// Remove inner padding and search cancel button in Safari and Chrome on OS X.
+// Safari (but not Chrome) clips the cancel button when the search input has
+// padding (and `textfield` appearance).
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+}
+
+// Define consistent border, margin, and padding.
+
+fieldset {
+    margin: 0 2px;
+    padding: .35em .625em .75em;
+    border: 1px solid #c0c0c0;
+}
+
+// 1. Correct `color` not being inherited in IE 8/9/10/11.
+// 2. Remove padding so people aren't caught out if they zero out fieldsets.
+
+legend {
+    padding: 0;
+    border: 0;
+}
+
+// Remove default vertical scrollbar in IE 8/9/10/11.
+
+textarea {
+    overflow: auto;
+}
+
+// Don't inherit the `font-weight` (applied by a rule above).
+// NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+
+optgroup {
+    font-weight: bold;
+}
+
+// Tables
+// ==========================================================================
+
+// Remove most spacing between table cells.
+
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+
+td,
+th {
+    padding: 0;
+}

--- a/src/styles/modules/_btn.scss
+++ b/src/styles/modules/_btn.scss
@@ -196,10 +196,7 @@
 }
 
 .dc-btn-group-row {
-    // FIXME: Prefer using placeholder selectors (e.g. %some-placeholder) with @extend
-    // scss-lint:disable PlaceholderInExtend
-    @extend .dc-cf;
-    // scss-lint:enable PlaceholderInExtend
+    @extend %dc-cf;
     clear: both;
 }
 

--- a/src/styles/modules/_dialog.scss
+++ b/src/styles/modules/_dialog.scss
@@ -65,7 +65,7 @@
 
 .dc-dialog__title {
     // scss-lint:disable PlaceholderInExtend
-    @extend .h3;
+    @extend .dc-h3;
     // scss-lint:enable PlaceholderInExtend
     display: inline-block;
     margin: 0 0 $dc-space50;
@@ -76,7 +76,7 @@
 
 .dc-dialog__subtitle {
     // scss-lint:disable PlaceholderInExtend
-    @extend .h4;
+    @extend .dc-h4;
     // scss-lint:enable PlaceholderInExtend
     display: inline-block;
     margin: 0 0 $dc-space50;

--- a/src/styles/modules/_dropdown.scss
+++ b/src/styles/modules/_dropdown.scss
@@ -1,9 +1,6 @@
 .dc-btn-dropdown,
 .dc-btn-dropup {
-    // FIXME: Prefer using placeholder selectors (e.g. %some-placeholder) with @extend
-    // scss-lint:disable PlaceholderInExtend
-    @extend .dc-cf;
-    // scss-lint:enable PlaceholderInExtend
+    @extend %dc-cf;
     position: relative;
 }
 


### PR DESCRIPTION
… dc-cf, remove normalize.css dep, use existing selectors

* copy and paste normalize.css, removing normalize.css deps
  please see (http://stackoverflow.com/questions/7111610/import-regular-css-file-in-scss-file) and (https://github.com/sass/sass/issues/193)
  importing css file doesn't work with evry version of sass/compass

* use placeholder syntax with dc-cf
* use existing selectors to avoid compiler errors (dc-h3, dc-h4)