### PR TITLE
refactor(typography): solve #140, remove .dc-html .dc-body classes...

### DIFF
--- a/docs/demo/views/layouts/default.html
+++ b/docs/demo/views/layouts/default.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="dc-html">
+<html>
 <head>
 
 	<meta charset="utf-8">
@@ -17,7 +17,7 @@
 
     <link rel="icon" href="favicon.ico">
 </head>
-<body class="dc-body dc-body--demo-breakpoints">
+<body class="dc-body--demo-breakpoints">
 	{{#if fabricator}}
 		<header class="f-header">
 			<img class="f-logo" src="assets/toolkit/img/logo.svg" alt="Zalando Logo">

--- a/src/styles/core/_typography.scss
+++ b/src/styles/core/_typography.scss
@@ -23,11 +23,15 @@
 }
 
 @mixin dc-html-selectors {
-    .dc-html {  @include dc-html;  }
+    html {
+        @include dc-html;
+    }
 }
 
 @mixin dc-body-selectors {
-    .dc-body {  @include dc-body;  }
+    body {
+        @include dc-body;
+    }
 }
 
 @mixin dc-box-sizing {


### PR DESCRIPTION
@xonic @mrac @gabrielhl @dami-gg @cjhowald WDYT?

refactor(typography): solve #140, remove .dc-html .dc-body classes, apply style directly on html and body because they are in any case required

	BREAKING CHANGE: .dc-html and .dc-body classes were removed.

	If you @include dc-typography-selectors (already included when import dress-code and @include dc-everything)
	you don't need anymore to use dc-html and dc-body classes, style is already applied to html and body.