### PR TITLE
feat(table): Use lighter color for hover background

### DIFF
--- a/src/styles/atoms/_table.scss
+++ b/src/styles/atoms/_table.scss
@@ -105,7 +105,7 @@
 
     @include breakpoint($dc-huge-width) {
         &:hover {
-            background: $dc-blue70;
+            background: $dc-blue80;
         }
     }
 }


### PR DESCRIPTION
Use $dc-blue80, it matches the current live version better (from CMS).