### PR TITLE
feat(pagination): add pagination molecule

### DIFF
--- a/docs/demo/materials/04-molecules/11-pagination.html
+++ b/docs/demo/materials/04-molecules/11-pagination.html
@@ -1,0 +1,66 @@
+---
+notes: |
+  Use `dc-pagination` as container, each button should have `dc-pagination-btn` class applied.
+
+  Active button can be highlighted with `dc-pagination-btn--active` modifier class.
+
+  Buttons can be disabled by adding `dc-pagination-btn--disabled` modifier class.
+
+  As shown below, optionally, you can add an icon button in-between to have hidden page range in the navigation.
+---
+<div class="dc-pagination">
+  <button class="dc-btn dc-pagination-btn">
+    <icon class="dc-icon dc-icon--btn dc-icon--arrow-left"></icon>
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    1
+  </button>
+  <button class="dc-btn dc-pagination-btn  dc-pagination-btn--active">
+    2
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    3
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    4
+  </button>
+  <button class="dc-btn dc-pagination-btn dc-pagination-btn--disabled">
+    <icon class="dc-icon dc-icon--more ng-scope" ng-if="page === 0"></icon>
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    10
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    <icon class="dc-icon dc-icon--btn dc-icon--arrow-right"></icon>
+  </button>
+</div>
+
+<div class="dc-pagination">
+  <button class="dc-btn dc-pagination-btn">
+    <icon class="dc-icon dc-icon--btn dc-icon--arrow-left"></icon>
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    1
+  </button>
+  <button class="dc-btn dc-pagination-btn dc-pagination-btn--disabled">
+    <icon class="dc-icon dc-icon--more ng-scope" ng-if="page === 0"></icon>
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    5
+  </button>
+  <button class="dc-btn dc-pagination-btn dc-pagination-btn--active">
+    6
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    7
+  </button>
+  <button class="dc-btn dc-pagination-btn dc-pagination-btn--disabled">
+    <icon class="dc-icon dc-icon--more ng-scope" ng-if="page === 0"></icon>
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    10
+  </button>
+  <button class="dc-btn dc-pagination-btn">
+    <icon class="dc-icon dc-icon--btn dc-icon--arrow-right"></icon>
+  </button>
+</div>

--- a/docs/demo/materials/04-molecules/11-pagination.html
+++ b/docs/demo/materials/04-molecules/11-pagination.html
@@ -15,7 +15,7 @@ notes: |
   <button class="dc-btn dc-pagination-btn">
     1
   </button>
-  <button class="dc-btn dc-pagination-btn  dc-pagination-btn--active">
+  <button class="dc-btn dc-pagination-btn dc-pagination-btn--active">
     2
   </button>
   <button class="dc-btn dc-pagination-btn">
@@ -25,7 +25,7 @@ notes: |
     4
   </button>
   <button class="dc-btn dc-pagination-btn dc-pagination-btn--disabled">
-    <icon class="dc-icon dc-icon--more ng-scope" ng-if="page === 0"></icon>
+    <icon class="dc-icon dc-icon--more"></icon>
   </button>
   <button class="dc-btn dc-pagination-btn">
     10
@@ -43,7 +43,7 @@ notes: |
     1
   </button>
   <button class="dc-btn dc-pagination-btn dc-pagination-btn--disabled">
-    <icon class="dc-icon dc-icon--more ng-scope" ng-if="page === 0"></icon>
+    <icon class="dc-icon dc-icon--more"></icon>
   </button>
   <button class="dc-btn dc-pagination-btn">
     5
@@ -55,7 +55,7 @@ notes: |
     7
   </button>
   <button class="dc-btn dc-pagination-btn dc-pagination-btn--disabled">
-    <icon class="dc-icon dc-icon--more ng-scope" ng-if="page === 0"></icon>
+    <icon class="dc-icon dc-icon--more"></icon>
   </button>
   <button class="dc-btn dc-pagination-btn">
     10

--- a/src/styles/dress-code.scss
+++ b/src/styles/dress-code.scss
@@ -35,7 +35,7 @@
 @import "molecules/search-form";
 @import "molecules/toast";
 @import "molecules/tooltip";
-
+@import "molecules/pagination";
 
 @mixin dc-everything {
     // core
@@ -76,4 +76,5 @@
     @include dc-search-form-selectors;
     @include dc-toast-selectors;
     @include dc-tooltip-selectors;
+    @include dc-pagination-selectors;
 }

--- a/src/styles/molecules/_pagination.scss
+++ b/src/styles/molecules/_pagination.scss
@@ -1,0 +1,46 @@
+// @import "./btn-group";
+
+@mixin dc-pagination {
+    @include dc-btn-group;
+}
+
+@mixin dc-pagination-btn {
+    @include dc-btn--in-btn-group;
+
+    background: $dc-white;
+    color: $dc-blue40;
+    cursor: pointer;
+
+    &:hover {
+        background: $dc-blue80;
+        color: $dc-blue40;
+    }
+
+    &--active {
+        padding-bottom: $dc-space75;
+        border-bottom: 4px solid $dc-orange50;
+    }
+
+    &--active,
+    &--disabled {
+        color: $dc-gray50;
+        cursor: default;
+
+        &:hover {
+            background: $dc-white;
+            color: $dc-gray50;
+            box-shadow: none;
+        }
+    }
+}
+
+@mixin dc-pagination-selectors {
+
+    .dc-pagination {
+        @include dc-pagination;
+    }
+
+    .dc-pagination-btn {
+        @include dc-pagination-btn;
+    }
+}


### PR DESCRIPTION
New pagination molecule with demo.

Here is how it looks:

<img width="341" alt="screen shot 2016-09-16 at 18 31 53" src="https://cloud.githubusercontent.com/assets/11697969/18593516/0bbeceb2-7c3c-11e6-909e-61a5145cc642.png">

Pagination is extended from the already existing button group. It just adds a few extra styles for active and disabled buttons within pagination (group). Also modifies the look and feel of default button group to pagination as per UX. 

closes #224 