### PR TITLE
fix(tables): table column in responsive mode to have a min height

### DIFF
--- a/src/styles/atoms/_table.scss
+++ b/src/styles/atoms/_table.scss
@@ -192,7 +192,7 @@
     @include breakpoint(0 $dc-huge-width - .1) {
         @include _dc-table-element--is-block;
 
-        min-height: 2.6rem;
+        min-height: 2rem;
         padding-left: calc(30% + 12px);
         text-align: left;
 

--- a/src/styles/atoms/_table.scss
+++ b/src/styles/atoms/_table.scss
@@ -192,9 +192,9 @@
     @include breakpoint(0 $dc-huge-width - .1) {
         @include _dc-table-element--is-block;
 
+        min-height: 2.6rem;
         padding-left: calc(30% + 12px);
         text-align: left;
-        min-height: 2.6rem;
 
         &:before {
             display: block;

--- a/src/styles/atoms/_table.scss
+++ b/src/styles/atoms/_table.scss
@@ -194,6 +194,7 @@
 
         padding-left: calc(30% + 12px);
         text-align: left;
+        min-height: 2.6rem;
 
         &:before {
             display: block;

--- a/src/styles/atoms/_table.scss
+++ b/src/styles/atoms/_table.scss
@@ -192,7 +192,7 @@
     @include breakpoint(0 $dc-huge-width - .1) {
         @include _dc-table-element--is-block;
 
-        min-height: 2rem;
+        min-height: 2.4rem;
         padding-left: calc(30% + 12px);
         text-align: left;
 


### PR DESCRIPTION
This is for fixing #267 - Added min height for the td in responsive mode. this prevents labels from  overlapping and shows empty cells instead.
The min height is same as the line-height used.

## Before Fix:
![image](https://cloud.githubusercontent.com/assets/11697969/19650580/1c3374aa-9a0a-11e6-9279-3ba014a25504.png)
_empty cells cause column headers to overlap_

<img width="763" alt="screen shot 2016-10-24 at 17 09 18" src="https://cloud.githubusercontent.com/assets/11697969/19651342/c3bc2b84-9a0c-11e6-9adb-745e67101266.png">
_with all cells empty in a row_

## After Fix:
<img width="746" alt="screen shot 2016-10-24 at 16 53 17" src="https://cloud.githubusercontent.com/assets/11697969/19650677/696d130c-9a0a-11e6-9bd5-e7bcdf6194ef.png">
_empty cells have min-height (and display as empty blocks) to prevent overlapping of column headers_

<img width="767" alt="screen shot 2016-10-24 at 17 09 54" src="https://cloud.githubusercontent.com/assets/11697969/19651361/d15a0810-9a0c-11e6-902c-dfb3be648922.png">
_with all cells empty in a row_


Closes #267