### PR TITLE
feat(dc-label__sub): add dc-label__sub mixins and classes

### DIFF
--- a/docs/demo/materials/03-atoms/forms/text-input.html
+++ b/docs/demo/materials/03-atoms/forms/text-input.html
@@ -1,13 +1,22 @@
 <label class="dc-label" for="optionalInput">Text Input</label>
 <input class="dc-input" type="text" id="optionalInput" placeholder="e. g. give an example"/>
 
-<label class="dc-label" for="numberInput">Number input</label>
+<label class="dc-label" for="numberInput">
+    Number input
+    <span class="dc-label__sub">optional</span>
+</label>
 <input class="dc-input" type="number" id="numberInput" placeholder="e. g. 100"/>
 
-<label class="dc-label dc-label--required" for="requiredInput">Required Input</label>
+<label class="dc-label" for="requiredInput">
+    Required Input
+    <span class="dc-label__sub">required</span>
+</label>
 <input class="dc-input" type="text" id="requiredInput"  placeholder="e. g. give an example"/>
 
-<label class="dc-label dc-label--required dc-label--is-error" for="errorInput">Required Input – Error</label>
+<label class="dc-label" for="errorInput">
+    Required Input – Error
+    <span class="dc-label__sub dc-label__sub--is-error">required</span>
+</label>
 <input class="dc-input dc-input--is-error" type="text" id="errorInput"  placeholder="e. g. give an example"/>
 <span class="dc--text-error">Please don't leave this empty.</span>
 

--- a/src/styles/atoms/_label.scss
+++ b/src/styles/atoms/_label.scss
@@ -9,16 +9,27 @@
     text-transform: uppercase;
 }
 
+@mixin dc-label__sub {
+    margin-left: $dc-space50;
+    color: $dc-gray50;
+    font-weight: 300;
+    text-transform: capitalize;
+}
+
+@mixin dc-label__sub--is-error {
+    color: $dc-red40;
+}
+
 @mixin dc-label--disabled {
     color: $dc-gray50;
 }
 
 @mixin dc-label--required {
+    // this mixin and related class is deprecated and will be removed in the next versions.
+    @warn "`dc-label--required` mixin is deprecated and will be removed in the next versions! use `dc-label__sub` instead.";
+
     &:after {
-        margin-left: $dc-space50;
-        color: $dc-gray50;
-        font-weight: 300;
-        text-transform: capitalize;
+        @include dc-label__sub;
         content: "Required";
     }
 }
@@ -31,6 +42,8 @@
 
 @mixin dc-label-selectors {
     .dc-label { @include dc-label; }
+    .dc-label__sub { @include dc-label__sub; }
+    .dc-label__sub--is-error { @include dc-label__sub--is-error; }
     .dc-label--disabled {  @include dc-label--disabled;  }
     .dc-label--required {  @include dc-label--required; }
     .dc-label--is-error {  @include dc-label--is-error; }


### PR DESCRIPTION
* Add dc-label__sub to replace dc-label--required to give the possibility to customize the wording and enable localization
* dc-label--required deprecated