### PR TITLE
Added missing title attribute to fabricator-assemble templates

### DIFF
--- a/docs/demo/views/01-core.html
+++ b/docs/demo/views/01-core.html
@@ -1,4 +1,5 @@
 ---
+title: The Dress Code | Core
 fabricator: true
 ---
 

--- a/docs/demo/views/02-structure-and-grid.html
+++ b/docs/demo/views/02-structure-and-grid.html
@@ -1,4 +1,5 @@
 ---
+title: The Dress Code | Page Structure and Grid
 fabricator: true
 ---
 

--- a/docs/demo/views/03-atoms.html
+++ b/docs/demo/views/03-atoms.html
@@ -1,4 +1,5 @@
 ---
+title: The Dress Code | Atoms
 fabricator: true
 ---
 

--- a/docs/demo/views/04-molecules.html
+++ b/docs/demo/views/04-molecules.html
@@ -1,4 +1,5 @@
 ---
+title: The Dress Code | Molecules
 fabricator: true
 ---
 

--- a/docs/demo/views/05-guidelines.html
+++ b/docs/demo/views/05-guidelines.html
@@ -1,4 +1,5 @@
 ---
+title: The Dress Code | Guidelines
 fabricator: true
 ---
 

--- a/docs/demo/views/docs.html
+++ b/docs/demo/views/docs.html
@@ -1,4 +1,5 @@
 ---
+title: The Dress Code | Docs
 fabricator: true
 ---
 


### PR DESCRIPTION
Fixed #337

There was missing the `title` attribute in all sub page fabricator-assemble templates within `docs/demo/views`.