### PR TITLE
fix(demo): fix table breaking demo layout

### DIFF
--- a/src/styles/atoms/_table.scss
+++ b/src/styles/atoms/_table.scss
@@ -199,7 +199,6 @@
     padding: $dc-space75 + .1 $dc-space50 $dc-space75 + .1;
     font-weight: $dc-normal-font-weight;
     line-height: $dc-body-line-height;
-    white-space: nowrap;
 
     &:first-child {
         padding-left: $dc-space100 / 2;


### PR DESCRIPTION
fix(demo): fix table breaking demo layout

With this update, table cells content can be multiline (text wrap)

close #374

### Before
<img width="1258" alt="before" src="https://user-images.githubusercontent.com/3602581/30684793-ea378b54-9eb2-11e7-81e8-ec6f518b3924.png">

### After
<img width="1264" alt="after" src="https://user-images.githubusercontent.com/3602581/30684794-ea37ab20-9eb2-11e7-9d70-263d24a68336.png">

