### PR TITLE
feat(buttons): focus styles added for buttons to make them accessible

### DIFF
--- a/docs/demo/materials/03-atoms/buttons/03-options.html
+++ b/docs/demo/materials/03-atoms/buttons/03-options.html
@@ -13,13 +13,19 @@ notes: |
   `dc-btn--disabled` Action is disabled. Buttons using this modifier should not be clickable.
 
   `dc-btn--link` Looks like a link but aligns and behaves like buttons. For secondary or tertiary actions.
+
+  `dc-btn--no-focus` Does not keep focus on the button when clicked.
 ---
 <button class="dc-btn dc-btn--primary">Primary Button</button>
 <button class="dc-btn dc-btn--destroy">Destroy Button</button>
 <button class="dc-btn dc-btn--active">Active Button</button>
-<button class="dc-btn dc-btn--disabled">Disabled Button</button>
+<button class="dc-btn dc-btn--disabled" disabled>Disabled Button</button>
+<button class="dc-btn dc-btn--no-focus">Button without focus</button>
+
 <br>
 <button class="dc-btn dc-btn--link">Button Link</button>
 <button class="dc-btn dc-btn--link dc-btn--destroy">Button Link - Destroy</button>
-<button class="dc-btn dc-btn--link dc-btn--disabled">Button Link - Disabled</button>
+<button class="dc-btn dc-btn--link dc-btn--disabled" disabled>Button Link - Disabled</button>
+<button class="dc-btn dc-btn--link dc-btn--no-focus">Button Link - without focus</button>
+
 <br>

--- a/src/styles/atoms/_btn.scss
+++ b/src/styles/atoms/_btn.scss
@@ -20,6 +20,7 @@
 
     &:focus {
         outline: none;
+        box-shadow: 0 0 0 2px transparentize($dc-blue40, 0.5);
     }
 
     &:hover {
@@ -49,6 +50,10 @@
     &:hover {
         @include _dc-btn--link-reset;
         color: $dc-link-color-hover;
+    }
+
+    &:focus {
+        box-shadow: 0 0 0 2px transparentize($dc-link-color, 0.5);
     }
 }
 
@@ -174,6 +179,13 @@
     }
 }
 
+@mixin dc-btn--no-focus {
+    &:focus {
+        outline: none;
+        box-shadow: none;
+    }
+}
+
 @mixin dc-btn-selectors {
     .dc-btn {  @include dc-btn;  }
 
@@ -194,6 +206,8 @@
     .dc-btn--large {  @include dc-btn--large;  }
 
     .dc-btn--block {  @include dc-btn--block;  }
+
+    .dc-btn--no-focus { @include dc-btn--no-focus; }
 
     // special case (usually this kind of selectors should be avoided)
     .dc-btn--link.dc-btn--disabled {  @include dc-btn--link-disabled;  }


### PR DESCRIPTION
Closes #379 

I have added a box-shadow highlight keeping the color closer to input highlights (but not exactly same as it needs to be visible for primary button which is also the same color background).

Introduced one more modifier for buttons as `dc-btn--no-focus` which can be used if the user wants to have no focus when clicked. 

Note: by default accessibility standards suggest to have a focus state on the button. Also if there is no focus state it is not possible to navigate a form through keyboard (tabs). This PR fixes that issue here for buttons.