### PR TITLE
docs(search): make search work with basepath

### DIFF
--- a/docs/demo/assets/scripts/index.js
+++ b/docs/demo/assets/scripts/index.js
@@ -1,3 +1,4 @@
 require('./prism');
 require('./interactions');
 require('./fabricator');
+require('./quick-search');

--- a/docs/demo/assets/scripts/quick-search.js
+++ b/docs/demo/assets/scripts/quick-search.js
@@ -1,0 +1,38 @@
+import Awesomplete from 'awesomplete';
+
+class QuickSearch {
+
+    constructor() {
+        this.searchField = document.getElementById('quick-search'),
+        this.materialsList = document.getElementById('materials-list'),
+        this.materials = this.materialsList.querySelectorAll('option');
+        this.initSearch();
+    }
+
+    /**
+     * Init quick search field
+     */
+    initSearch() {
+        new Awesomplete(this.searchField);
+
+        // Listen for change and go to URL
+        this.searchField.addEventListener('awesomplete-selectcomplete', (e) => {
+
+            let url = e.currentTarget.value;
+
+            // Reset the value
+            e.currentTarget.value = '';
+
+            if (url) {
+                window.location = window.location.origin + url;
+            }
+        });
+
+        // Autofocus field when there’s no hash in the URL
+        if (!window.location.hash.length) {
+            this.searchField.focus();
+        }
+    }
+}
+
+window.QuickSearch = new QuickSearch();

--- a/docs/demo/assets/styles/main.scss
+++ b/docs/demo/assets/styles/main.scss
@@ -9,6 +9,8 @@
 
 // dress code
 @import "../../../../src/styles/index";
+@import "../../../../node_modules/awesomplete/awesomplete";
+
 
 @import 'partials/mixins';
 @import 'partials/variables';
@@ -30,3 +32,5 @@
 
 // Exceptions to the elements' CSS
 @import 'partials/exceptions';
+
+@import "partials/awesomplete";

--- a/docs/demo/assets/styles/partials/_awesomplete.scss
+++ b/docs/demo/assets/styles/partials/_awesomplete.scss
@@ -1,0 +1,50 @@
+.f-search-materials {
+    padding: 0 15px;
+    width: 100%;
+    margin: 0;
+}
+
+.f-search-form {
+    width: 100%;
+}
+
+.awesomplete {
+    width: 100%;
+    & > ul {
+        border-radius: 2px;
+
+        & > li {
+            padding: $dc-space100 $dc-space75;
+            line-height: 1.63rem;
+        }
+
+        & > li:hover {
+            background: $dc-blue70;
+            color: black;
+        }
+
+        & > li[aria-selected="true"] {
+            background: $dc-blue30;
+            color: white;
+        }
+    }
+
+    mark {
+        background: $dc-yellow70;
+    }
+
+    li:hover mark {
+        background: $dc-yellow40;
+    }
+
+    li[aria-selected="true"] mark {
+        background: $dc-blue20;
+    }
+
+    & > input {
+        width: 100%;
+        &::-webkit-calendar-picker-indicator {
+            display: none;
+        }
+    }
+}

--- a/docs/demo/assets/styles/partials/_item.scss
+++ b/docs/demo/assets/styles/partials/_item.scss
@@ -5,10 +5,6 @@
 	padding-bottom: 3rem;
 	border-bottom: 1px solid map-get($dc-colors, light);
 
-	&.f-item-grouped_groups {
-		@include dc-card;
-	}
-
 	&:last-child {
 		border-bottom: 0;
 		margin-bottom: 0;
@@ -33,6 +29,13 @@
 			margin-bottom: 0;
 			padding-bottom: 0;
 		}
+	}
+
+	&[id]:before {
+		content: '';
+		margin-top: -50px;
+		padding-top: 50px;
+		display: block;
 	}
 }
 

--- a/docs/demo/views/layouts/includes/f-item.html
+++ b/docs/demo/views/layouts/includes/f-item.html
@@ -1,22 +1,24 @@
-<div class="f-item-group f-item-grouped_groups" id="{{@key}}">
-
-{{#if items}}
-	<div class="f-item-heading-group">
-		<h2 class="dc-h2 f-item-heading" data-f-toggle="labels">{{name}}</h2>
-	</div>
-	{{#each items}}
-		<div class="f-item-group" id="{{@key}}">
-			<div class="f-item-heading-group" data-f-toggle="labels">
-				{{> f-item-controls}}
-				<h3 class="dc-h3 f-item-heading">{{name}}</h3>
-			</div>{{> f-item-content this}}
-		</div>
-	{{/each}}
-{{else}}
-	<div class="f-item-heading-group" data-f-toggle="labels">
-		{{> f-item-controls}}
-		<h2 class="dc-h2 f-item-heading">{{name}}</h2>
-	</div>{{> f-item-content this}}
-{{/if}}
-
+<div class="dc-card f-item-group">
+    <div class="f-item-group" id="{{@key}}">
+        {{#if items}}
+        <div class="f-item-heading-group">
+            <h2 class="dc-h2 f-item-heading" data-f-toggle="labels">{{name}}</h2>
+        </div>
+        {{#each items}}
+        <div class="f-item-group" id="{{@key}}">
+            <div class="f-item-heading-group" data-f-toggle="labels">
+                {{> f-item-controls}}
+                <h3 class="dc-h3 f-item-heading">{{name}}</h3>
+            </div>
+            {{> f-item-content this}}
+        </div>
+        {{/each}}
+        {{else}}
+        <div class="f-item-heading-group" data-f-toggle="labels">
+            {{> f-item-controls}}
+            <h2 class="dc-h2 f-item-heading">{{name}}</h2>
+        </div>
+        {{> f-item-content this}}
+        {{/if}}
+    </div>
 </div>

--- a/docs/demo/views/layouts/includes/f-menu.html
+++ b/docs/demo/views/layouts/includes/f-menu.html
@@ -3,6 +3,8 @@
 
 	{{> f-controls}}
 
+    {{> f-quick-search}}
+
 	<ul>
 
 		<li>

--- a/docs/demo/views/layouts/includes/f-quick-search.html
+++ b/docs/demo/views/layouts/includes/f-quick-search.html
@@ -1,0 +1,24 @@
+<div class="f-search-materials">
+    <div class="dc-search-form f-search-form">
+        <input type="text" id="quick-search"
+                                        class="dc-input dc-search-form__input" list="materials-list"
+                                        placeholder="Quick search…"
+                                        data-autofirst="true">
+        <button class="dc-btn dc-search-form__btn">
+            <i class="dc-icon dc-icon--search dc-icon--interactive"></i>
+        </button>
+        <datalist id="materials-list">
+            {{#each materials}}
+            {{#each items}}
+            {{#if items}}
+            {{#each items}}
+            <option value="/{{@../../key}}.html#{{@key}}">{{../name}} &middot; {{name}}</option>
+            {{/each}}
+            {{else}}
+            <option value="/{{@../key}}.html#{{@key}}">{{name}}</option>
+            {{/if}}
+            {{/each}}
+            {{/each}}
+        </datalist>
+    </div>
+</div>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "awesomplete": "^1.1.2",
     "babel-core": "^6.26.0",
     "babel-loader": "7.1.1",
     "babel-preset-es2015": "^6.9.0",


### PR DESCRIPTION
In live demo there is a basepath `dress-code` which was breaking the previous navigation logic for search.

This change replaces the last fragment of the url (after last '/') with the new path. 