### PR TITLE
docs(code): fix code alignment in the docs

### DIFF
--- a/docs/demo/views/layouts/includes/f-item.html
+++ b/docs/demo/views/layouts/includes/f-item.html
@@ -10,7 +10,8 @@
                 {{> f-item-controls}}
                 <h3 class="dc-h3 f-item-heading">{{name}}</h3>
             </div>
-            {{> f-item-content this}}
+<!-- Indentation removed for item-content so as there is no whitespace in the output. Whitespace affects the 'pre' code in the demo-->
+{{> f-item-content this}}
         </div>
         {{/each}}
         {{else}}
@@ -18,7 +19,8 @@
             {{> f-item-controls}}
             <h2 class="dc-h2 f-item-heading">{{name}}</h2>
         </div>
-        {{> f-item-content this}}
+<!-- Indentation removed for item-content so as there is no whitespace in the output. Whitespace affects the 'pre' code in the demo-->
+{{> f-item-content this}}
         {{/if}}
     </div>
 </div>


### PR DESCRIPTION
- Fix layout template to not have whitespace for item contents

Closes #420