### PR TITLE
chore(regression): fix regular expression for release branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - npm install
 script:
 - npm run lint
-- if [[ "$TRAVIS_BRANCH" == *release ]]; then 
+- if [[ "$TRAVIS_PULL_REQUEST_BRANCH" =~ ^release\/.*$ ]]; then 
     git lfs pull; 
     npm run test:minified; 
   else 


### PR DESCRIPTION
Fixed now since I was using an environment variable called TRAVIS_BRANCH which on PRs always points to the branch you want to merge into, i.e. master.

It now works:

![image](https://user-images.githubusercontent.com/3198244/34262826-cb874034-e66d-11e7-8f9b-21b944d6d50f.png)


Closes #423 